### PR TITLE
Change API URL in Schedule from /events/currUsersEvents to just /events

### DIFF
--- a/mobile/src/events/Schedule.tsx
+++ b/mobile/src/events/Schedule.tsx
@@ -35,7 +35,7 @@ const Schedule: React.FC<{}> = () => {
       try {
         const authToken = await SecureStore.getItemAsync("wigo-auth-token");
         const res = await fetch(
-          'http://localhost:8000/events/currUsersEvents',
+          'http://localhost:8000/events',
           {
             headers: {
               "Content-Type": "application/json;charset=utf-8",


### PR DESCRIPTION
In my previous PR, after I changed the backend route to be /events, I neglected to reflect this change in the Schedule.tsx file where this route is called.  Now, the Schedule.tsx file calls the appropriate route to get the events for a specific user. 