### PR TITLE
Create Popup for Event Conflict

### DIFF
--- a/mobile/src/events/CreateModifyEvent.tsx
+++ b/mobile/src/events/CreateModifyEvent.tsx
@@ -12,6 +12,7 @@ import {
   createEventOnSubmit,
   modifyEventOnSubmit,
 } from "./eventsService";
+import { ConflictAction, eventConflictAlert, isConflictingEvent } from "./eventConflicts";
 
 export const repetitionValues = [
   { label: "Does not repeat", value: "no_repeat" },
@@ -64,7 +65,24 @@ const CreateModifyEvent: React.FC<Props> = ({ navigation, route }) => {
               }
         }
         validationSchema={validateEventSchema}
-        onSubmit={(values) => {
+        onSubmit={async (values) => {
+          let action: ConflictAction = ConflictAction.scheduleEvent;
+          // Check if event conflicts, and set action to the value chosen by the user 
+          if (isConflictingEvent()) {
+            await eventConflictAlert().then((userChosenAction: ConflictAction) => {
+              action = userChosenAction;
+            });
+          } 
+
+          // User wants to continue editing the event
+          if (action as ConflictAction === ConflictAction.editEvent) {
+            return; 
+          }
+          // User wants to schedule event at suggested time
+          if (action as ConflictAction == ConflictAction.suggestedTime) {
+            // TO DO: SET VALUES TO SUGGESTED TIME
+          }
+
           if (event) {
             modifyEventOnSubmit({ ...values, id: event.id } as Event);
           } else {

--- a/mobile/src/events/CreateModifyEvent.tsx
+++ b/mobile/src/events/CreateModifyEvent.tsx
@@ -12,7 +12,11 @@ import {
   createEventOnSubmit,
   modifyEventOnSubmit,
 } from "./eventsService";
-import { ConflictAction, eventConflictAlert, isConflictingEvent } from "./eventConflicts";
+import {
+  ConflictAction,
+  eventConflictAlert,
+  isConflictingEvent,
+} from "./eventConflicts";
 
 export const repetitionValues = [
   { label: "Does not repeat", value: "no_repeat" },
@@ -67,19 +71,21 @@ const CreateModifyEvent: React.FC<Props> = ({ navigation, route }) => {
         validationSchema={validateEventSchema}
         onSubmit={async (values) => {
           let action: ConflictAction = ConflictAction.scheduleEvent;
-          // Check if event conflicts, and set action to the value chosen by the user 
+          // Check if event conflicts, and set action to the value chosen by the user
           if (isConflictingEvent()) {
-            await eventConflictAlert().then((userChosenAction: ConflictAction) => {
-              action = userChosenAction;
-            });
-          } 
+            await eventConflictAlert().then(
+              (userChosenAction: ConflictAction) => {
+                action = userChosenAction;
+              }
+            );
+          }
 
           // User wants to continue editing the event
-          if (action as ConflictAction === ConflictAction.editEvent) {
-            return; 
+          if ((action as ConflictAction) === ConflictAction.editEvent) {
+            return;
           }
           // User wants to schedule event at suggested time
-          if (action as ConflictAction == ConflictAction.suggestedTime) {
+          if ((action as ConflictAction) == ConflictAction.suggestedTime) {
             // TO DO: SET VALUES TO SUGGESTED TIME
           }
 

--- a/mobile/src/events/eventConflicts.ts
+++ b/mobile/src/events/eventConflicts.ts
@@ -1,42 +1,43 @@
-import { Alert} from "react-native";
+import { Alert } from "react-native";
 import Event from "../types/Event";
 
 export enum ConflictAction {
-  editEvent,   // Return to event page to edit event
-  suggestedTime,  // Schedule the event with the suggested time
+  editEvent, // Return to event page to edit event
+  suggestedTime, // Schedule the event with the suggested time
   scheduleEvent, // Schedule the conflicting evet
 }
 
-export const eventConflictAlert = () => new Promise<ConflictAction>((resolve) => {
-  Alert.alert(
-    "Event Conflicts",
-    "This event will conflict with </Insert event it conflicts with & new suggested time/>",
-    [
-      {
-        text: "Schedule Event at <Insert suggested time/>",
-        onPress: () => {
+export const eventConflictAlert = () =>
+  new Promise<ConflictAction>((resolve) => {
+    Alert.alert(
+      "Event Conflicts",
+      "This event will conflict with </Insert event it conflicts with & new suggested time/>",
+      [
+        {
+          text: "Schedule Event at <Insert suggested time/>",
+          onPress: () => {
             resolve(ConflictAction.suggestedTime);
+          },
+          style: "cancel",
         },
-        style: "cancel"
-      },
-      {
-        text: "Edit Time",
-        onPress: () => {
-          resolve(ConflictAction.editEvent);
+        {
+          text: "Edit Time",
+          onPress: () => {
+            resolve(ConflictAction.editEvent);
+          },
+          style: "default",
         },
-        style: "default"
-      },
-      { 
-        text: "Schedule Event Anyway", 
-        onPress: () => {
+        {
+          text: "Schedule Event Anyway",
+          onPress: () => {
             resolve(ConflictAction.scheduleEvent);
+          },
+          style: "destructive",
         },
-        style: "destructive"
-    }
-    ],
-  );
-});
+      ]
+    );
+  });
 
 export const isConflictingEvent = (): boolean => {
-    return true;
-}
+  return true;
+};

--- a/mobile/src/events/eventConflicts.ts
+++ b/mobile/src/events/eventConflicts.ts
@@ -1,0 +1,42 @@
+import { Alert} from "react-native";
+import Event from "../types/Event";
+
+export enum ConflictAction {
+  editEvent,   // Return to event page to edit event
+  suggestedTime,  // Schedule the event with the suggested time
+  scheduleEvent, // Schedule the conflicting evet
+}
+
+export const eventConflictAlert = () => new Promise<ConflictAction>((resolve) => {
+  Alert.alert(
+    "Event Conflicts",
+    "This event will conflict with </Insert event it conflicts with & new suggested time/>",
+    [
+      {
+        text: "Schedule Event at <Insert suggested time/>",
+        onPress: () => {
+            resolve(ConflictAction.suggestedTime);
+        },
+        style: "cancel"
+      },
+      {
+        text: "Edit Time",
+        onPress: () => {
+          resolve(ConflictAction.editEvent);
+        },
+        style: "default"
+      },
+      { 
+        text: "Schedule Event Anyway", 
+        onPress: () => {
+            resolve(ConflictAction.scheduleEvent);
+        },
+        style: "destructive"
+    }
+    ],
+  );
+});
+
+export const isConflictingEvent = (): boolean => {
+    return true;
+}


### PR DESCRIPTION
Creates a popup up if the event the user is creating/modifying will create conflicts. The user can choose to schedule it anyway, edit its time, or schedule it with a suggested non conflicting time.

NOTE: this currently uses a dummy function (that always returns true) to check if the event has conflicts. This will be changed to utilize issue #84 once an individual can check if an event will conflict.

NOTE 2: This currently doesn't incorporate a new 'suggested time' but does create the space for it. I expect this will occur during the mini-sprint (I can accomplish this during the mini-sprint).

Screen with popup.
<img width="414" alt="Screen Shot 2020-12-07 at 1 43 51 PM" src="https://user-images.githubusercontent.com/70663801/101399563-4131d700-3895-11eb-8675-5d64a03798f3.png">
