### PR TITLE
fixes bug with pod interaction after it is first created

### DIFF
--- a/mobile/src/pods/CreatePod.tsx
+++ b/mobile/src/pods/CreatePod.tsx
@@ -4,7 +4,7 @@ import Button from "../shared/Button";
 import { Formik } from "formik";
 import * as SecureStore from "expo-secure-store";
 import apiUrl from "../config";
-import { setPod as reduxSetPod } from "./podSlice";
+import { setPod as reduxSetPod, loadUserPods } from "./podSlice";
 import sharedStyles from "../sharedStyles";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -58,6 +58,7 @@ const CreatePod: React.FC<Props> = ({ navigation, route }) => {
                 dispatch(reduxSetPod(pod));
                 setPod(pod);
               }
+              dispatch(loadUserPods());
               navigation.navigate("PodsHomeScreen", { pod: pod });
             }
           }}


### PR DESCRIPTION
Fixes bug with pod after creation. Previously, if a user were to Create a Pod and then click "Manage Members," the app would crash. This PR fixes the issue but triggering a reload of the pod set in the RootState after pod creation. 