### PR TITLE
Fix two event bugs In deployment (conflicting, deleting) 

### DIFF
--- a/api/src/routes/eventConflictFunctions.ts
+++ b/api/src/routes/eventConflictFunctions.ts
@@ -185,6 +185,7 @@ export const getOverlappingEvents = (
   const eventsAdded = new Set();
   const conflictingEvents = [];
 
+  // Checking if proposed event exists inside any existing events 
   existingEvents.forEach((event) => {
     if (
       event.start_time <= proposedEvent.start_time &&
@@ -196,10 +197,11 @@ export const getOverlappingEvents = (
     endpointTimes.push(new Endpoint(event.end_time, event));
   });
 
+  // Seeing if any end point is in between the proposed start and end time 
   for (const endpoint of endpointTimes) {
     if (
-      endpoint.time >= proposedEvent.start_time &&
-      endpoint.time <= proposedEvent.end_time &&
+      endpoint.time >= new Date(proposedEvent.start_time) &&
+      endpoint.time <= new Date(proposedEvent.end_time) &&
       !eventsAdded.has(endpoint.event.id)
     ) {
       conflictingEvents.push(endpoint.event);

--- a/mobile/src/events/eventsService.ts
+++ b/mobile/src/events/eventsService.ts
@@ -162,7 +162,7 @@ export const handleDeleteEvent = async (
 ): Promise<Event | null> => {
   const data = { id: values.id };
   try {
-    const res = await fetch(`http://localhost:8000/events`, {
+    const res = await fetch(`${apiUrl}/events`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json;charset=utf-8",


### PR DESCRIPTION
1. Deleting event was using local host url so failed in deployment
2. Conflicting Events: endpoint was a date, not a string in deployment so could not directly compare.

Not fixed: conflicting times with travel time isnt working