### PR TITLE
When Start Time Changes, Change End Time

### DIFF
--- a/mobile/src/events/CreateModifyEvent.tsx
+++ b/mobile/src/events/CreateModifyEvent.tsx
@@ -5,6 +5,7 @@ import Button from "../shared/Button";
 import DropDownPicker from "react-native-dropdown-picker";
 import sharedStyles from "../sharedStyles";
 import { useDispatch } from "react-redux";
+import moment from "moment";
 
 /** Import Custom Components */
 import LocationPicker from "./LocationPicker";
@@ -16,7 +17,6 @@ import Event from "../types/Event";
 import { ProposedEventConflicts, SuggestedTime } from "./eventConflictService";
 import EventConflictModal from "./EventConflictModal";
 import DeleteEventModal from "./DeleteEventModal";
-import podSlice from "../pods/podSlice";
 import Pod from "../types/Pod";
 
 /** Import Helpers */
@@ -46,7 +46,7 @@ const CreateModifyEvent: React.FC<CreateModifyEventProps> = ({
   const [start_time, setStartTime] = useState(
     event ? event.start_time : new Date()
   );
-  // End time = current time + 1 hour
+  // End time = current time + 1 hour initially
   const [end_time, setEndTime] = useState(
     event ? event.end_time : new Date(Date.now() + 60 * 60 * 1000)
   );
@@ -63,6 +63,16 @@ const CreateModifyEvent: React.FC<CreateModifyEventProps> = ({
   // Allows you to pass dispatch into helper functions
   const helperDispatch = (thingToDispatch: any) => {
     dispatch(thingToDispatch);
+  };
+
+  // When the start time changes, change the endTime to the start Time + current event length
+  const startTimeChange = (newStartTime: Date) => {
+    // Calculate current event length
+    const duration = moment.duration(moment(end_time).diff(start_time));
+    setStartTime(newStartTime);
+    setEndTime(
+      moment(newStartTime).add(duration.asMinutes(), "minutes").toDate()
+    );
   };
 
   return (
@@ -161,7 +171,12 @@ const CreateModifyEvent: React.FC<CreateModifyEventProps> = ({
             <GeneralEventInput
               inputTitle="Start Time"
               GeneralInputComponent={
-                <DatePicker name="start_time" date={start_time} />
+                <DatePicker
+                  name="start_time"
+                  date={start_time}
+                  startTimeChange={startTimeChange}
+                  endTimeChange={setEndTime}
+                />
               }
               error={
                 touched.start_time && errors.start_time
@@ -174,7 +189,12 @@ const CreateModifyEvent: React.FC<CreateModifyEventProps> = ({
             <GeneralEventInput
               inputTitle="End Time"
               GeneralInputComponent={
-                <DatePicker name="end_time" date={end_time} />
+                <DatePicker
+                  name="end_time"
+                  date={end_time}
+                  startTimeChange={startTimeChange}
+                  endTimeChange={setEndTime}
+                />
               }
               error={!!errors.end_time ? (errors.end_time as String) : ""}
             />

--- a/mobile/src/events/DatePicker.tsx
+++ b/mobile/src/events/DatePicker.tsx
@@ -8,6 +8,8 @@ import sharedStyles from "../sharedStyles";
 type Props = {
   name: string;
   date: Date;
+  startTimeChange: (startDate: Date) => void;
+  endTimeChange: React.Dispatch<React.SetStateAction<Date>>;
 };
 
 enum State {
@@ -25,11 +27,25 @@ const DatePicker: React.FC<Props> = (props) => {
   const { setFieldValue } = useFormikContext();
   const [field] = useField(props.name);
 
+  // If prop date changes because of updates in other date picker
+  React.useEffect(() => {
+    setDate(props.date);
+    setFieldValue(props.name, props.date);
+  }, [props.date]);
+
+  // If user changes date on this date time picker
   const onChange = (event, selectedDate) => {
     // Set date on calendar UI
     setDate(selectedDate);
     // Set date in form
     setFieldValue(props.name, selectedDate);
+
+    // Send new time up to parent
+    if (props.name == "start_time") {
+      props.startTimeChange(selectedDate);
+    } else {
+      props.endTimeChange(selectedDate);
+    }
   };
 
   const handleDatePress = () => {


### PR DESCRIPTION
Current behavior:
When the start time changes, update the end time to be the amount of time after the start time that the previous event length was. Change nothing when the end time changes.

This behavior was modeled off of the google calendar event creation.